### PR TITLE
[MIN-19] Setup ci for develop branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
   pull_request:
     branches:
       - main
+      - develop
   push:
     branches:
       - main
+      - develop
 
 jobs:
   ci-tests:


### PR DESCRIPTION
This PR updates `ci.yml` so that CI will run on both `develop` and `main` branch.