### PR TITLE
[MIN-30] Remove Python 3.8 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.10"]
     timeout-minutes: 15
 
     # disable zenml analytics logging for ci


### PR DESCRIPTION
Requests html, for some unknown reason, does not work with Javascript webpages on Python 3.9 or below. 

As a result, we impose a limit of using 3.10 and above (ZenML requires < 3.11) and remove 3.8 from the GitHub CI.