### PR TITLE
[MIN-18] Migrate old pipelines and steps

### DIFF
--- a/pipelines/data_preparation_pipeline/data_preparation_pipeline.py
+++ b/pipelines/data_preparation_pipeline/data_preparation_pipeline.py
@@ -1,6 +1,4 @@
 """Data preparation pipeline."""
-
-
 from steps.data_preparation_steps import clean_data, load_data, validate_data
 from zenml import pipeline
 from zenml.logger import get_logger

--- a/pipelines/data_scraping_pipeline/data_scraping_pipeline.py
+++ b/pipelines/data_scraping_pipeline/data_scraping_pipeline.py
@@ -1,16 +1,13 @@
 """Data scraping pipeline."""
+from steps.data_scraping_steps import scrape_mind_data, scrape_nhs_data
+from zenml import pipeline
 from zenml.logger import get_logger
-from zenml.pipelines import pipeline
-from zenml.steps import BaseStep
 
 logger = get_logger(__name__)
 
 
 @pipeline
-def data_scraping_pipeline(
-    scrape_nhs_data: BaseStep,
-    scrape_mind_data: BaseStep,
-) -> None:
+def data_scraping_pipeline() -> None:
     """The data scraping pipeline.
 
     Args:

--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-"""Run all pipeline."""
+"""Run all pipelines."""
 import click
 from pipelines.data_preparation_pipeline.data_preparation_pipeline import (
     data_preparation_pipeline,
@@ -7,7 +7,6 @@ from pipelines.data_scraping_pipeline.data_scraping_pipeline import (
     data_scraping_pipeline,
 )
 from pipelines.deployment_pipeline.deployment_pipeline import deployment_pipeline
-from steps.data_scraping_steps import scrape_mind_data, scrape_nhs_data
 from zenml.logger import get_logger
 
 logger = get_logger(__name__)
@@ -15,10 +14,10 @@ logger = get_logger(__name__)
 
 def run_data_scrapping_pipeline() -> None:
     """Run all steps in the data scrapping pipeline."""
-    pipeline = data_scraping_pipeline(scrape_nhs_data(), scrape_mind_data())
-    pipeline.run(
+    pipeline = data_scraping_pipeline.with_options(
         config_path="pipelines/data_scraping_pipeline/config_data_scraping_pipeline.yaml"
     )
+    pipeline()
 
 
 def run_data_preparation_pipeline() -> None:

--- a/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
+++ b/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
@@ -6,8 +6,8 @@ from typing import Dict, List, Optional
 import pandas as pd
 from bs4 import BeautifulSoup
 from requests_html import HTMLSession  # type: ignore
+from zenml import step
 from zenml.logger import get_logger
-from zenml.steps import step
 
 logger = get_logger(__name__)
 

--- a/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
+++ b/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Union
 import pandas as pd
 from bs4 import BeautifulSoup, NavigableString, Tag
 from requests_html import HTMLSession  # type: ignore
-from zenml.steps import step
+from zenml import step
 
 
 class NHSMentalHealthScraper:


### PR DESCRIPTION
This PR updates the `data_scraping_pipeline`,  and all steps inclusive, by replacing the deprecated `@step` and `@pipeline` decorators with the new versions and updating `run.py` with the new specification on how to call/run pipelines. See https://docs.zenml.io/user-guide/advanced-guide/migrate-your-old-pipelines-and-steps for more detail.