### PR TITLE
[MIN-45] Update Streamlit app to get the inference endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,24 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
 docs
 
 .matcha
 .mypy_cache/
+
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -318,3 +318,4 @@ pip-selfcheck.json
 
 .vscode
 .idea
+.matcha

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Run the deployment pipeline.
 python run.py -d
 ```
 
+## Streamlit Application
+
+After running the deployment pipeline is a success, run the following command to start a streamlit application.
+
+```bash
+streamlit run app/app.py
+```
+
 # &#129309; Acknowledgements
 
 This project wouldn't be possible without the exceptional content on both the Mind and NHS Mental Health websites.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python run.py -d
 
 ## Streamlit Application
 
-After running the deployment pipeline is a success, run the following command to start a streamlit application.
+Once the deployment has completed, run the following command to start a streamlit application.
 
 ```bash
 streamlit run app/app.py

--- a/app/app.py
+++ b/app/app.py
@@ -3,13 +3,16 @@ import json
 import os
 import time
 from typing import Any, Dict, List, Optional
-
 import requests
 import streamlit as st
 
+from zenml.integrations.seldon.model_deployers.seldon_model_deployer import (
+    SeldonModelDeployer,
+)
+
 PIPELINE_NAME = "deployment_pipeline"
-PIPELINE_STEP = "deploy_model"
-MODEL_NAME = "placeholder"
+PIPELINE_STEP = "seldon_llm_model_deployer_step"
+MODEL_NAME = "seldon-llm-custom-model"
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 st.set_page_config(
@@ -34,7 +37,18 @@ def _get_prediction_endpoint() -> Optional[str]:
     Returns:
         Optional[str]: the url endpoint if it exists and is valid, None otherwise.
     """
-    return None
+    try:
+        model_deployer = SeldonModelDeployer.get_active_model_deployer()
+
+        deployed_services = model_deployer.find_model_server(
+            pipeline_name=PIPELINE_NAME,
+            pipeline_step_name=PIPELINE_STEP,
+            model_name=MODEL_NAME,
+        )
+
+        return deployed_services[0].prediction_url
+    except Exception:
+        return None
 
 
 def _create_payload(

--- a/app/app.py
+++ b/app/app.py
@@ -30,7 +30,7 @@ st.caption(
 st.session_state.error_placeholder = st.empty()
 
 
-@st.cache_data
+@st.cache_data(show_spinner=False)
 def _get_prediction_endpoint() -> Optional[str]:
     """Get the endpoint for the currently deployed LLM model.
 

--- a/setup_deploy.sh
+++ b/setup_deploy.sh
@@ -14,6 +14,7 @@ function get_state_value() {
     echo "$value"
 }
 
+echo "Extracting resource names and assigning it to a variable..."
 zenml_storage_path=$(get_state_value pipeline storage-path)
 zenml_connection_string=$(get_state_value pipeline connection-string)
 k8s_context=$(get_state_value orchestrator k8s-context)
@@ -43,7 +44,8 @@ echo "Setting up ZenML..."
     zenml model-deployer register seldon_deployer --flavor=seldon \
             --kubernetes_context=$k8s_context \
             --kubernetes_namespace=$seldon_workload_namespace \
-            --base_url=http://$seldon_ingress_host
+            --base_url=http://$seldon_ingress_host  \
+
     zenml stack register llm_test_stack -i docker_builder -a az_store -o default -c acr_registry --model_deployer=seldon_deployer --set
 } >> setup_out.log
 


### PR DESCRIPTION
In the current implementation for streamlit  application, the `get_inference_endpoint` [function](https://github.com/fuzzylabs/MindGPT/blob/develop/app/app.py#L31) just returns `None`. 

In this PR, we update the  `get_inference_endpoint` function to query the seldon model deployer component in zenml stack to return a endpoint url. This endpoint url will be used by streamlit application to recieve/send query/responses.

To test this application locally, follow the instructions in Deployment pipeline [section](https://github.com/fuzzylabs/MindGPT#deployment-pipeline) of Readme.

After deployment pipeline runs successfully, run the following to start the application

```bash
streamlit run app/app.py 
```