### PR TITLE
[MIN-57] Add a new column for uuid in the data scraping step

### DIFF
--- a/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
+++ b/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
@@ -85,7 +85,7 @@ class Scraper:
 
         df["timestamp"] = datetime.now()
 
-        df["uuid"] = df.apply(lambda row: uuid.uuid4(), axis=1)
+        df["uuid"] = df.apply(lambda row: str(uuid.uuid4()), axis=1)
 
         df = df[["uuid", "text_scraped", "timestamp", "url"]]  # Rearrange Columns
 

--- a/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
+++ b/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
@@ -1,6 +1,7 @@
 """Scrape data from the Mind charity website."""
 import os
 import time
+import uuid
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -84,7 +85,9 @@ class Scraper:
 
         df["timestamp"] = datetime.now()
 
-        df = df[["text_scraped", "timestamp", "url"]]  # Rearrange Columns
+        df["uuid"] = df.apply(lambda row: uuid.uuid4(), axis=1)
+
+        df = df[["uuid", "text_scraped", "timestamp", "url"]]  # Rearrange Columns
 
         return df
 

--- a/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
+++ b/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
@@ -1,6 +1,7 @@
 """Scrape data from the NHS website."""
 import os.path
 import re
+import uuid
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
@@ -87,6 +88,7 @@ class NHSMentalHealthScraper:
         return pd.DataFrame(
             [
                 {
+                    "uuid": uuid.uuid4(),
                     "text_scraped": target.get_text(" "),
                     "timestamp": timestamp,
                     "url": self._url,

--- a/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
+++ b/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
@@ -88,7 +88,7 @@ class NHSMentalHealthScraper:
         return pd.DataFrame(
             [
                 {
-                    "uuid": uuid.uuid4(),
+                    "uuid": str(uuid.uuid4()),
                     "text_scraped": target.get_text(" "),
                     "timestamp": timestamp,
                     "url": self._url,

--- a/tests/test_steps/test_data_scraping_steps/test_scrape_mind_data.py
+++ b/tests/test_steps/test_data_scraping_steps/test_scrape_mind_data.py
@@ -159,7 +159,9 @@ def test_create_dataframe(scraper: Scraper):
     )
 
     assert isinstance(result_df, pd.DataFrame)
-    assert {"text_scraped", "url", "timestamp"} == set(result_df.columns.tolist())
+    assert {"uuid", "text_scraped", "url", "timestamp"} == set(
+        result_df.columns.tolist()
+    )
     assert_frame_equal(
         result_df[["text_scraped", "url"]], expected_df[["text_scraped", "url"]]
     )
@@ -285,7 +287,6 @@ def test_scrape_mind_data():
                 "Test h2 text\nTest p text\nText li text",
                 "Test h2 text\nTest p text\nText li text",
             ],
-            "timestamp": ["20230625", "20230625", "20230625"],
             "url": [
                 "https://www.mind.org.uk/test_side_bar_object_1_url/",
                 "https://www.mind.org.uk/test_side_bar_exclude_me/",
@@ -295,7 +296,9 @@ def test_scrape_mind_data():
     )
 
     assert isinstance(result_df, pd.DataFrame)
-    assert {"text_scraped", "url", "timestamp"} == set(result_df.columns.tolist())
+    assert {"uuid", "text_scraped", "url", "timestamp"} == set(
+        result_df.columns.tolist()
+    )
     assert_frame_equal(
         result_df[["text_scraped", "url"]], expected_df[["text_scraped", "url"]]
     )

--- a/tests/test_steps/test_data_scraping_steps/test_scrape_nhs_data.py
+++ b/tests/test_steps/test_data_scraping_steps/test_scrape_nhs_data.py
@@ -18,7 +18,7 @@ def expected_columns() -> set:
     Returns:
         set: a set containing the expected columns
     """
-    return {"text_scraped", "timestamp", "url"}
+    return {"uuid", "text_scraped", "timestamp", "url"}
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR updates the data scraping steps by integrating UUIDs into each row of data. This avoids the need to perform this step in the embedding pipeline, preventing duplicate entries in the Chroma database caused by distinct UUIDs being generated with each pipeline run.

What's changed:
- In the `scrape_mind_data_step`, the `create_dataframe()` function is modified to include UUIDs generated into a new column named 'uuid'.
- In the `scrape_nhs_data_step`, the `scrape()` function now returns a DataFrame with a 'uuid' column containing UUIDs generated using the `uuid4()` function.
- The tests for both scraping steps have been updated to verify that the generated DataFrames include the 'uuid' column.
