### PR TITLE
[MIN-32] Add DataFrame specifications to docstrings where required

### DIFF
--- a/steps/data_preparation_steps/clean_data_step/clean_data_step.py
+++ b/steps/data_preparation_steps/clean_data_step/clean_data_step.py
@@ -80,7 +80,14 @@ def clean_data(data: pd.DataFrame) -> pd.DataFrame:
         data (pd.DataFrame): The scraped data.
 
     Returns:
-        The cleaned data in the new format described above.
+        pd.DataFrame: The cleaned data in the new format described above.
+            Index:
+                RangeIndex
+            Columns:
+                Name: uuid, dtype: object
+                Name: text_scraped, dtype: object
+                Name: timestamp, dtype: datetime64[ns]
+                Name: url, dtype: object
     """
     data = data.dropna().copy()
 

--- a/steps/data_preparation_steps/load_data_step/load_data_step.py
+++ b/steps/data_preparation_steps/load_data_step/load_data_step.py
@@ -34,7 +34,21 @@ def load_data() -> Output(mind_df=pd.DataFrame, nhs_df=pd.DataFrame):  # type: i
 
     Returns:
         mind_data (pd.DataFrame): Raw scraped data from the Mind website
+            Index:
+                RangeIndex
+            Columns:
+                Name: uuid, dtype: object
+                Name: text_scraped, dtype: object
+                Name: timestamp, dtype: datetime64[ns]
+                Name: url, dtype: object
         nhs_data (pd.DataFrame): Raw scraped data from the NHS website
+            Index:
+                RangeIndex
+            Columns:
+                Name: uuid, dtype: object
+                Name: text_scraped, dtype: object
+                Name: timestamp, dtype: datetime64[ns]
+                Name: url, dtype: object
     """
     mind_df, nhs_df = _read_data()
 

--- a/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
+++ b/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
@@ -80,6 +80,13 @@ class Scraper:
 
         Returns:
             pd.DataFrame: The created DataFrame with columns TextScraped, TimeStamp, URL, and ArchivedURL.
+                Index:
+                    RangeIndex
+                Columns:
+                    Name: uuid, dtype: object
+                    Name: text_scraped, dtype: object
+                    Name: timestamp, dtype: datetime64[ns]
+                    Name: url, dtype: object
         """
         df = pd.DataFrame(data.items(), columns=["url", "text_scraped"])
 
@@ -281,6 +288,13 @@ def scrape_mind_data() -> pd.DataFrame:
 
     Returns:
         pd.DataFrame: data scraped.
+            Index:
+                RangeIndex
+            Columns:
+                Name: uuid, dtype: object
+                Name: text_scraped, dtype: object
+                Name: timestamp, dtype: datetime64[ns]
+                Name: url, dtype: object
     """
     scraper = Scraper()
     data: Dict[str, str] = {}

--- a/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
+++ b/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
@@ -81,7 +81,14 @@ class NHSMentalHealthScraper:
         """A method for scraping the text from target pages.
 
         Returns:
-            (DataFrame): a Pandas DataFrame with four columns ("text_scraped", "timestamp", "url") and a single record representing the results of the scrape.
+            pd.DataFrame: a Pandas DataFrame with four columns ("text_scraped", "timestamp", "url") and a single record representing the results of the scrape.
+                Index:
+                    RangeIndex
+                Columns:
+                    Name: uuid, dtype: object
+                    Name: text_scraped, dtype: object
+                    Name: timestamp, dtype: datetime64[ns]
+                    Name: url, dtype: object
         """
         timestamp = datetime.now()
         target = self._identify_target()
@@ -127,7 +134,18 @@ class NHSMentalHealthScraper:
 
 @step
 def scrape_nhs_data() -> pd.DataFrame:
-    """A ZenML pipeline step for scraping the NHS Mental Health website."""
+    """A ZenML pipeline step for scraping the NHS Mental Health website.
+
+    Returns:
+        pd.DataFrame: a Pandas DataFrame with four columns ("text_scraped", "timestamp", "url") and a single record representing the results of the scrape.
+            Index:
+                RangeIndex
+            Columns:
+                Name: uuid, dtype: object
+                Name: text_scraped, dtype: object
+                Name: timestamp, dtype: datetime64[ns]
+                Name: url, dtype: object
+    """
     nhs_scraper = NHSMentalHealthScraper(
         url="https://www.nhs.uk/mental-health/",
         attributes={"class": "nhsuk-main-wrapper"},


### PR DESCRIPTION
This PR updates the doc string in the `scrape_mind_data_step`,`scrape_nhs_data_step`, `clean_data_step` and `load_data_step`. More specifically, the return section of the doc string now includes information about the data frame such as the columns that it should have the the data type of each column.

What's changed:
- In `scrape_mind_data_step.py`, the doc string for the two functions that return a dataframe is updated.
- In `scrape_nhs_data_step.py`, the doc string for the two functions that return a dataframe is updated.
- In `load_data_step.py`, the doc string for the `load_data()` is updated.
- In `clean_data_step.py`, the doc string for the `clean_data()` is updated.