### PR TITLE
[MIN-61] fix failing test due to dvc module detecting develop branch

### DIFF
--- a/tests/test_steps/test_data_versioning_steps/test_version_data_step.py
+++ b/tests/test_steps/test_data_versioning_steps/test_version_data_step.py
@@ -54,5 +54,8 @@ def test_push_block_reached():
 
 def test_error_raised_if_files_not_present():
     """Test that the files_exist function is called and an appropriate error raised when called without files present."""
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FileNotFoundError), patch(
+        "steps.data_versioning_steps.version_data_step.get_active_branch_name"
+    ) as branch_name:
+        branch_name.return_value = "not_develop"
         version_data("test_", ["test_", "test_0"], False)


### PR DESCRIPTION
This PR fixes the failing test_error_raised_if_file_not_present reported by @Christopher-Norman. 

The issue was that `get_active_branch_name` when called by CI on develop returns develop, as it should, but there's a check in `version_data()` to stop users unintentionally pushing directly to develop. 

The fix mocks the `get_active_branch_name` method such that it returns "not_develop" as the branch name as the test is looking at the dvc functionality anyway and is expected to raise an before any git or dvc action is taken.