### PR TITLE
[MIN-75] Add function to post LLM responses to metric service from Streamlit app

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -301,6 +301,7 @@ def main() -> None:
 
             # Get seldon endpoint
             prediction_endpoint = _get_prediction_endpoint()
+
             # Get the metric service endpoint
             metric_service_endpoint = _get_metric_service_endpoint()
 

--- a/app/app.py
+++ b/app/app.py
@@ -9,6 +9,7 @@ import streamlit as st
 from chromadb.api import API
 from chromadb.api.types import EmbeddingFunction
 from chromadb.utils import embedding_functions
+from requests.models import Response
 from utils.chroma_store import ChromaStore
 
 logging.basicConfig(
@@ -236,7 +237,9 @@ def query_llm(prediction_endpoint: str, messages: Dict[str, str]) -> str:
     return summary_txt
 
 
-def post_response_to_metric_service(metric_service_endpoint: str, response: str) -> str:
+def post_response_to_metric_service(
+    metric_service_endpoint: str, response: str
+) -> Response:
     """Send the LLM's response to the metric service for readability computation using a POST request.
 
     Args:
@@ -244,12 +247,12 @@ def post_response_to_metric_service(metric_service_endpoint: str, response: str)
         response (str): the response produced by the LLM
 
     Returns:
-        str: the message received in response to the POST request
+        Response: the post request response
     """
     response_dict = {"response": response}
     result = requests.post(url=metric_service_endpoint, json=response_dict)
 
-    return result.text
+    return result
 
 
 def show_disclaimer() -> bool:
@@ -309,7 +312,7 @@ def main() -> None:
             embed_function = _get_embedding_function(DEFAULT_EMBED_MODEL)
 
             if metric_service_endpoint is None:
-                logging.info("Metric service endpoint is None, monitoring is disabled.")
+                logging.warn("Metric service endpoint is None, monitoring is disabled.")
 
             if prediction_endpoint is None or chroma_client is None:
                 st.session_state.error_placeholder.error(
@@ -345,7 +348,7 @@ def main() -> None:
                             result = post_response_to_metric_service(
                                 metric_service_endpoint, assistant_response
                             )
-                            logging.info(result)
+                            logging.info(result.text)
 
                     message_placeholder.markdown(full_response)
 

--- a/app/app.py
+++ b/app/app.py
@@ -96,11 +96,11 @@ def _get_prediction_endpoint() -> Optional[str]:
 
 
 @st.cache_data(show_spinner=False)
-def _get_metric_service_endpoint() -> Optional[str]:
+def _get_metric_service_endpoint() -> str:
     """Get the endpoint for the currently deployed metric service.
 
     Returns:
-        Optional[str]: the url endpoint if it exists and is valid, None otherwise.
+        str: the url endpoint if it exists and is valid, None otherwise.
     """
     return f"http://{METRIC_SERVICE_NAME}.{METRIC_SERVICE_NAMESPACE}:{METRIC_SERVICE_PORT}/readability"
 


### PR DESCRIPTION
This PR implements the necessary logic enabling Streamlit to transmit the LLM response received to the metric service, which is hosted on k8s. This transmission is carried out via a POST request. Two new functions have been implemented:

- `_get_metric_service_endpoint()`: This function is used for assembling the metric service endpoint similar to how the prediction endpoint function operates.
- `post_response_to_metric_service()`: This function handles the preparation of the payload and its transmission through a POST request.

The payload is constructed within the `post_response_to_metric_service()` function rather than having its own dedicated function, as done for the prediction payload because it only consists of a single line of code.

In addition, logging have been added to Streamlit, enabling users to view the response message from the POST request sent to the metric service.