### PR TITLE
[MIN-89] Update chunk_size and chunk_overlap for mind and nhs data

### DIFF
--- a/pipelines/data_embedding_pipeline/data_embedding_pipeline.py
+++ b/pipelines/data_embedding_pipeline/data_embedding_pipeline.py
@@ -22,12 +22,14 @@ def data_embedding_pipeline() -> None:
         embed_model_type="base",
         data_version="data/first_version",
         collection_name="mind_data",
+        chunk_size=780,
+        chunk_overlap=50,
     )
     embed_data(
         nhs_df,
         embed_model_type="base",
         data_version="data/first_version",
         collection_name="nhs_data",
-        chunk_size=1000,
-        chunk_overlap=200,
+        chunk_size=2000,
+        chunk_overlap=50,
     )


### PR DESCRIPTION
Following the experimentation from [MIN-83](https://fuzzy-labs.atlassian.net/browse/MIN-83) ticket, we experimented with different values of `chunk_size` and `chunk_overlap` parameters.

Following on the results, we can use `chunk_size=780` and `chunk_overlap=50` for mind and `chunk_size=2000` and `chunk_overlap=50` for nhs as thresholds. (These values are tuned towards 3 depression questions and use 2 data points as a dataset).

Note: These values are not representative of the entire dataset and are specific to depression 3 questions as part of the experiment.

[MIN-83]: https://fuzzy-labs.atlassian.net/browse/MIN-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ