### PR TITLE
[MIN-99] Add a tag column to the metric database

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -74,7 +74,7 @@ Aim to retain the most important points, providing a coherent and readable summa
 Please avoid unnecessary details or tangential points.
 {context}
 Question: {question}
-Helpful Answer:"""
+Helpful Answer:""",
 }
 
 st.set_page_config(
@@ -273,18 +273,19 @@ def query_llm(
 
 
 def post_response_to_metric_service(
-    metric_service_endpoint: str, response: str
+    metric_service_endpoint: str, response: str, dataset: str
 ) -> Response:
     """Send the LLM's response to the metric service for readability computation using a POST request.
 
     Args:
         metric_service_endpoint (str): the metric service endpoint where the readability is computed
         response (str): the response produced by the LLM
+        dataset (str): the dataset that was used to generate the response.
 
     Returns:
         Response: the post request response
     """
-    response_dict = {"response": response}
+    response_dict = {"response": response, "dataset": dataset.lower()}
     result = requests.post(url=metric_service_endpoint, json=response_dict)
 
     return result
@@ -307,9 +308,16 @@ def show_disclaimer() -> None:
 def show_settings() -> None:
     """Show inference settings on the sidebar."""
     st.title("Settings")
-    st.session_state.temperature = st.slider("Temperature", min_value=0.0, max_value=2.0, value=0.8)
-    st.session_state.max_length = st.slider("Max response length", min_value=50, max_value=500, value=300, step=1)
-    st.session_state.prompt_template = st.select_slider("Prompt template", options=["simple", "complex", "advanced"], value="simple")
+    st.session_state.temperature = st.slider(
+        "Temperature", min_value=0.0, max_value=2.0, value=0.8
+    )
+    st.session_state.max_length = st.slider(
+        "Max response length", min_value=50, max_value=500, value=300, step=1
+    )
+    st.session_state.prompt_template = st.select_slider(
+        "Prompt template", options=["simple", "complex", "advanced"], value="simple"
+    )
+
 
 def show_sidebar():
     """Show the sidebar."""
@@ -398,7 +406,7 @@ def main() -> None:
 
                         if metric_service_endpoint:
                             result = post_response_to_metric_service(
-                                metric_service_endpoint, assistant_response
+                                metric_service_endpoint, assistant_response, source
                             )
                             logging.info(result.text)
 

--- a/data/mind_data_validated.csv.dvc
+++ b/data/mind_data_validated.csv.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 027332cb6e506fd47d3962471c1246d2
-  size: 1859742
+- md5: c76568f0dd939286c633b2ed3a557630
+  size: 2336306
   hash: md5
   path: mind_data_validated.csv

--- a/data/nhs_data_validated.csv.dvc
+++ b/data/nhs_data_validated.csv.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1534192fdce6f9c7bde650cf0374629c
-  size: 797289
+- md5: c4b3c09b6499a4faeec99fd7dbc27d4f
+  size: 811904
   hash: md5
   path: nhs_data_validated.csv

--- a/monitoring/metric_service/app.py
+++ b/monitoring/metric_service/app.py
@@ -31,17 +31,18 @@ def readability() -> Response:
     llm_response_dict = request.get_json()
 
     try:
-        validated_response = validate_llm_response(llm_response_dict)
+        validated_response, dataset = validate_llm_response(llm_response_dict)
         score = compute_readability(validated_response)
     except Exception as e:  # catch any exception from response validation
         return jsonify({"status_code": 400, "message": f"Validation error: {str(e)}"})
 
-    db_interface.insert_readability_data(float(score))
+    db_interface.insert_readability_data(float(score), str(dataset))
 
     return jsonify(
         {
             "status_code": 200,
             "score": score,
+            "dataset": dataset,
             "message": "Readability data has been successfully inserted.",
         }
     )

--- a/monitoring/metric_service/metric_service.py
+++ b/monitoring/metric_service/metric_service.py
@@ -1,5 +1,5 @@
 """Functions for the metric service for computing readability and validate llm response and embedding drift data."""
-from typing import Dict, Union
+from typing import Dict, Tuple, Union
 
 import textstat
 
@@ -33,7 +33,7 @@ def compute_readability(llm_response: str) -> float:
     return float(textstat.flesch_reading_ease(llm_response))
 
 
-def validate_llm_response(llm_response_dict: Dict[str, str]) -> str:
+def validate_llm_response(llm_response_dict: Dict[str, str]) -> Tuple[str, str]:
     """This function validate the payload which should be a dictionary containing the response text.
 
     Args:
@@ -46,7 +46,7 @@ def validate_llm_response(llm_response_dict: Dict[str, str]) -> str:
         ValueError: raise if the model response received is a empty string
 
     Returns:
-        str: the validated response text
+        Tuple[str, str]: the validated response text
     """
     if not isinstance(llm_response_dict, dict):
         raise TypeError("The model response is not a dictionary.")
@@ -54,7 +54,12 @@ def validate_llm_response(llm_response_dict: Dict[str, str]) -> str:
     response = llm_response_dict.get("response")
     if response is None:
         raise ValueError(
-            "The response dictionary does not contain the right key value pair."
+            "The response dictionary does not contain the response key value pair."
+        )
+    dataset = llm_response_dict.get("dataset")
+    if dataset is None:
+        raise ValueError(
+            "The response dictionary does not contain the dataset key value pair."
         )
 
     if not isinstance(response, str):
@@ -62,7 +67,12 @@ def validate_llm_response(llm_response_dict: Dict[str, str]) -> str:
     elif len(response) == 0:
         raise ValueError("The model response must not be an empty string.")
 
-    return response
+    if not isinstance(dataset, str):
+        raise TypeError("The name of the dataset is not a string.")
+    elif len(dataset) == 0:
+        raise ValueError("The dataset name must not be an empty string.")
+
+    return response, dataset
 
 
 def validate_embedding_drift_data(
@@ -85,6 +95,7 @@ def validate_embedding_drift_data(
         "current_dataset": str,
         "distance": float,
         "drifted": bool,
+        "dataset": str,
     }
 
     for key, expected_type in required_keys_types.items():

--- a/steps/data_embedding_steps/compute_embedding_drift_step/compute_embedding_drift_step.py
+++ b/steps/data_embedding_steps/compute_embedding_drift_step/compute_embedding_drift_step.py
@@ -105,12 +105,12 @@ def build_embedding_drift_payload(
     """
     drifted = distance > 0
 
-    formatted_reference_data_version = f"'{reference_data_version}'"
-    formatted_current_data_version = f"'{current_data_version}'"
+    # formatted_reference_data_version = f"'{reference_data_version}'"
+    # formatted_current_data_version = f"'{current_data_version}'"
 
     return {
-        "reference_dataset": f"{formatted_reference_data_version}",
-        "current_dataset": f"{formatted_current_data_version}",
+        "reference_dataset": reference_data_version,
+        "current_dataset": current_data_version,
         "distance": distance,
         "drifted": drifted,
         "dataset": dataset,

--- a/steps/data_embedding_steps/compute_embedding_drift_step/compute_embedding_drift_step.py
+++ b/steps/data_embedding_steps/compute_embedding_drift_step/compute_embedding_drift_step.py
@@ -105,9 +105,6 @@ def build_embedding_drift_payload(
     """
     drifted = distance > 0
 
-    # formatted_reference_data_version = f"'{reference_data_version}'"
-    # formatted_current_data_version = f"'{current_data_version}'"
-
     return {
         "reference_dataset": reference_data_version,
         "current_dataset": current_data_version,

--- a/steps/generic_steps/load_data_step/load_data_step.py
+++ b/steps/generic_steps/load_data_step/load_data_step.py
@@ -56,4 +56,4 @@ def load_data(
     mind_df = pd.read_csv(mind_file_path)
     nhs_df = pd.read_csv(nhs_file_path)
 
-    return data_version, reference_data_version, mind_df, nhs_df
+    return data_version, reference_data_version, mind_df[:3], nhs_df[:3]

--- a/steps/generic_steps/load_data_step/load_data_step.py
+++ b/steps/generic_steps/load_data_step/load_data_step.py
@@ -56,4 +56,4 @@ def load_data(
     mind_df = pd.read_csv(mind_file_path)
     nhs_df = pd.read_csv(nhs_file_path)
 
-    return data_version, reference_data_version, mind_df[:3], nhs_df[:3]
+    return data_version, reference_data_version, mind_df, nhs_df

--- a/tests/test_monitoring/test_metric_service.py
+++ b/tests/test_monitoring/test_metric_service.py
@@ -13,10 +13,19 @@ from monitoring.metric_service.metric_service import (
     "response, expectation",
     [
         (int(123), pytest.raises(TypeError)),
-        ({"incorrect key": "mock response"}, pytest.raises(ValueError)),
-        ({"response": int(123)}, pytest.raises(TypeError)),
-        ({"response": ""}, pytest.raises(ValueError)),
-        ({"response": "mock response"}, does_not_raise()),
+        (
+            {"incorrect key": "mock response", "dataset": "mock_dataset"},
+            pytest.raises(ValueError),
+        ),
+        (
+            {"response": "mock response", "incorrect key": "mock_dataset"},
+            pytest.raises(ValueError),
+        ),
+        ({"response": int(123), "dataset": "mock_dataset"}, pytest.raises(TypeError)),
+        ({"response": "", "dataset": "mock_dataset"}, pytest.raises(ValueError)),
+        ({"response": "mock response", "dataset": int(123)}, pytest.raises(TypeError)),
+        ({"response": "mock response", "dataset": ""}, pytest.raises(ValueError)),
+        ({"response": "mock response", "dataset": "mock_dataset"}, does_not_raise()),
     ],
 )
 def test_validate_llm_response(response: dict, expectation: pytest.raises) -> None:
@@ -57,6 +66,7 @@ def test_readability_score_for_good_sentences() -> None:
                 "current_dataset": 1.2,
                 "distance": 0.1,
                 "drifted": True,
+                "dataset": "nhs",
             },
             pytest.raises(TypeError),
         ),
@@ -66,6 +76,7 @@ def test_readability_score_for_good_sentences() -> None:
                 "current_dataset": "str",
                 "distance": 0.1,
                 "drifted": True,
+                "dataset": "mind",
             },
             pytest.raises(TypeError),
         ),
@@ -75,6 +86,7 @@ def test_readability_score_for_good_sentences() -> None:
                 "current_dataset": "1.2",
                 "distance": False,
                 "drifted": True,
+                "dataset": "nhs",
             },
             pytest.raises(TypeError),
         ),
@@ -84,23 +96,54 @@ def test_readability_score_for_good_sentences() -> None:
                 "current_dataset": "1.2",
                 "distance": 0.1,
                 "drifted": "True",
+                "dataset": "mind",
             },
             pytest.raises(TypeError),
         ),
         (
-            {"current_dataset": "1.2", "distance": 0.1, "drifted": "True"},
+            {
+                "reference_dataset": "1.1",
+                "current_dataset": "1.2",
+                "distance": 0.1,
+                "drifted": "True",
+                "dataset": 0.1,
+            },
+            pytest.raises(TypeError),
+        ),
+        (
+            {
+                "current_dataset": "1.2",
+                "distance": 0.1,
+                "drifted": "True",
+                "dataset": "nhs",
+            },
             pytest.raises(KeyError),
         ),
         (
-            {"reference_dataset": "1.1", "distance": 0.1, "drifted": "True"},
+            {
+                "reference_dataset": "1.1",
+                "distance": 0.1,
+                "drifted": "True",
+                "dataset": "nhs",
+            },
             pytest.raises(KeyError),
         ),
         (
-            {"reference_dataset": "1.1", "current_dataset": "1.2", "drifted": "True"},
+            {
+                "reference_dataset": "1.1",
+                "current_dataset": "1.2",
+                "drifted": "True",
+                "dataset": "nhs",
+            },
             pytest.raises(KeyError),
         ),
         (
-            {"reference_dataset": "1.1", "current_dataset": "1.2", "distance": 0.1},
+            {
+                "reference_dataset": "1.1",
+                "current_dataset": "1.2",
+                "distance": 0.1,
+                "dataset": "nhs",
+            },
             pytest.raises(KeyError),
         ),
         (
@@ -109,6 +152,16 @@ def test_readability_score_for_good_sentences() -> None:
                 "current_dataset": "1.2",
                 "distance": 0.1,
                 "drifted": True,
+            },
+            pytest.raises(KeyError),
+        ),
+        (
+            {
+                "reference_dataset": "1.1",
+                "current_dataset": "1.2",
+                "distance": 0.1,
+                "drifted": True,
+                "dataset": "nhs",
             },
             does_not_raise(),
         ),

--- a/tests/test_steps/test_data_embedding_steps/test_compute_embedding_drift_step.py
+++ b/tests/test_steps/test_data_embedding_steps/test_compute_embedding_drift_step.py
@@ -89,13 +89,14 @@ def test_calculate_euclidean_distance_expected_result():
 
 def test_build_embedding_drift_payload():
     """Test that the build_embedding_drift_payload function returns the expected dictionary payload."""
-    result = build_embedding_drift_payload("test_version", "test_version", 1.1)
+    result = build_embedding_drift_payload("test_version", "test_version", 1.1, "nhs")
 
     assert result == {
-        "reference_dataset": "'test_version'",
-        "current_dataset": "'test_version'",
+        "reference_dataset": "test_version",
+        "current_dataset": "test_version",
         "distance": 1.1,
         "drifted": True,
+        "dataset": "nhs",
     }
 
 
@@ -108,12 +109,18 @@ def test_compute_embedding_drift_step():
         "steps.data_embedding_steps.compute_embedding_drift_step.compute_embedding_drift_step.ChromaStore"
     ) as mock_chroma, patch(
         "steps.data_embedding_steps.compute_embedding_drift_step.compute_embedding_drift_step.requests.post"
-    ) as mock_post_requests:
+    ) as mock_post_requests, patch(
+        "steps.data_embedding_steps.compute_embedding_drift_step.compute_embedding_drift_step.COLLECTION_NAME_MAP"
+    ) as mock_collection_name_map:
         mock_chroma_instance = mock_chroma.return_value
         mock_chroma_instance.fetch_reference_and_current_embeddings.return_value = (
             mock_reference_embedding,
             mock_current_embedding,
         )
+
+        mock_collection_name_map.return_value = {
+            "mock_collection_name": "mock_collection"
+        }
 
         mock_post_requests.return_value.text = "OK"
 

--- a/tests/test_utils/test_metric_database.py
+++ b/tests/test_utils/test_metric_database.py
@@ -1,7 +1,6 @@
 """Test suite for testing metric database utility."""
 import os
 from contextlib import nullcontext as does_not_raise
-from typing import Dict, Union
 from unittest import mock
 from unittest.mock import patch
 
@@ -53,52 +52,64 @@ def test_validate_env() -> None:
         database_credentials.validate_env()
 
 
-def test_query_is_correct_with_readability_data() -> None:
-    """Test that the insert_readability_data query is built as expected based on the argument passed."""
-    mock_score: float = 88
-
+def test_insert_query_is_correct_for_readability_relation() -> None:
+    """Test that the insert_readability_data query is built as expected."""
     expected_query = """
-            INSERT INTO "readability" ("time_stamp", "readability_score")
-            VALUES (NOW(), 88);
+            INSERT INTO readability (time_stamp, readability_score, dataset)
+            VALUES (NOW(), %(score)s, %(dataset)s);
         """.strip()
 
-    generated_query = SQLQueries.insert_readability_data(mock_score).strip()
+    generated_query = SQLQueries.insert_readability_data().strip()
 
     assert generated_query == expected_query
 
 
-def test_query_is_correct_with_embedding_data_dict() -> None:
-    """Test that the insert_embedding_drift_data query is built as expected based on the argument passed."""
-    mock_data_dict: Dict[str, Union[str, float, bool]] = {
-        "reference_dataset": "1.1",
-        "current_dataset": "1.2",
-        "distance": 0.1,
-        "drifted": True,
-    }
-
+def test_insert_query_is_correct_for_embedding_drift_relation() -> None:
+    """Test that the insert_embedding_drift_data query is built as expected."""
     expected_query = """
-            INSERT INTO "embedding_drift" ("time_stamp", "reference_dataset", "current_dataset", "distance", "drifted")
-            VALUES (NOW(), 1.1, 1.2, 0.1, True);
+            INSERT INTO embedding_drift (time_stamp, reference_dataset, current_dataset, distance, drifted, dataset)
+            VALUES (NOW(), %(reference_dataset)s, %(current_dataset)s, %(distance)s, %(drifted)s, %(dataset)s);
         """.strip()
 
-    generated_query = SQLQueries.insert_embedding_drift_data(mock_data_dict).strip()
+    generated_query = SQLQueries.insert_embedding_drift_data().strip()
 
     assert generated_query == expected_query
 
 
-def test_query_is_correct_with_relation_name() -> None:
-    """Test that the relation_existence_query is built as expected based on the argument passed."""
-    mock_relation_name: str = "mock_name"
+def test_insert_query_is_correct_for_datasets_relation() -> None:
+    """Test that the insert_datasets_data query is built as expected."""
+    expected_query = """
+            INSERT INTO datasets (name)
+            VALUES (%(name)s);
+        """.strip()
 
+    generated_query = SQLQueries.insert_datasets_data().strip()
+
+    assert generated_query == expected_query
+
+
+def test_query_is_correct_for_relation_existence_query() -> None:
+    """Test that the relation_existence_query is built as expected."""
     expected_query = """
             SELECT EXISTS (
                 SELECT FROM pg_tables
                 WHERE  schemaname = 'public'
-                AND    tablename  = 'mock_name'
+                AND    tablename  = %(relation_name)s
             );
             """.strip()
 
-    generated_query = SQLQueries.relation_existence_query(mock_relation_name).strip()
+    generated_query = SQLQueries.relation_existence_query().strip()
+
+    assert generated_query == expected_query
+
+
+def test_query_is_correct_get_data_from_relation_query() -> None:
+    """Test that the get_data_from_relation query built as expected."""
+    expected_query = """
+            SELECT * FROM %(relation_name)s
+            """.strip()
+
+    generated_query = SQLQueries.get_data_from_relation().strip()
 
     assert generated_query == expected_query
 
@@ -114,6 +125,11 @@ def test_database_interface():
 
         mock_check_relation_existence.assert_called()
 
+        db_interface.create_relation("datasets")
+        mock_execute_query.assert_called_with(
+            SQLQueries.create_datasets_relation_query()
+        )
+
         db_interface.create_relation("readability")
         mock_execute_query.assert_called_with(
             SQLQueries.create_readability_relation_query()
@@ -124,26 +140,43 @@ def test_database_interface():
             SQLQueries.create_embedding_drift_relation_query()
         )
 
-        db_interface.insert_readability_data(1)
-        mock_execute_query.assert_called_with(SQLQueries.insert_readability_data(1))
+        db_interface.insert_datasets_data()
+        mock_execute_query.assert_called_with(
+            SQLQueries.insert_datasets_data(),
+            {
+                "name": "mind"  # This must be mind as it calls with nhs first and then mind.
+            },
+        )
+
+        db_interface.insert_readability_data(1, "nhs")
+        mock_execute_query.assert_called_with(
+            SQLQueries.insert_readability_data(), {"score": 1, "dataset": "nhs"}
+        )
 
         mock_embedding_drift_data = {
             "reference_dataset": "1.1",
             "current_dataset": "1.2",
             "distance": 0.1,
             "drifted": True,
+            "dataset": "nhs",
         }
         db_interface.insert_embedding_drift_data(mock_embedding_drift_data)
         mock_execute_query.assert_called_with(
-            SQLQueries.insert_embedding_drift_data(mock_embedding_drift_data)
+            SQLQueries.insert_embedding_drift_data(),
+            mock_embedding_drift_data,
         )
 
         db_interface.query_relation("readability")
         mock_execute_query.assert_called_with(
-            SQLQueries.get_data_from_relation("readability"), fetch=True
+            SQLQueries.get_data_from_relation(), "readability", fetch=True
         )
 
         db_interface.query_relation("embedding_drift")
         mock_execute_query.assert_called_with(
-            SQLQueries.get_data_from_relation("embedding_drift"), fetch=True
+            SQLQueries.get_data_from_relation(), "embedding_drift", fetch=True
+        )
+
+        db_interface.query_relation("datasets")
+        mock_execute_query.assert_called_with(
+            SQLQueries.get_data_from_relation(), "datasets", fetch=True
         )

--- a/tests/test_utils/test_metric_database.py
+++ b/tests/test_utils/test_metric_database.py
@@ -168,15 +168,21 @@ def test_database_interface():
 
         db_interface.query_relation("readability")
         mock_execute_query.assert_called_with(
-            SQLQueries.get_data_from_relation(), "readability", fetch=True
+            SQLQueries.get_data_from_relation(),
+            {"relation_name": "readability"},
+            fetch=True,
         )
 
         db_interface.query_relation("embedding_drift")
         mock_execute_query.assert_called_with(
-            SQLQueries.get_data_from_relation(), "embedding_drift", fetch=True
+            SQLQueries.get_data_from_relation(),
+            {"relation_name": "embedding_drift"},
+            fetch=True,
         )
 
         db_interface.query_relation("datasets")
         mock_execute_query.assert_called_with(
-            SQLQueries.get_data_from_relation(), "datasets", fetch=True
+            SQLQueries.get_data_from_relation(),
+            {"relation_name": "datasets"},
+            fetch=True,
         )

--- a/utils/metric_database.py
+++ b/utils/metric_database.py
@@ -191,10 +191,10 @@ class DatabaseInterface:
     """Class containing methods for interacting with the postgres database."""
 
     relation_names = {
-        "datasets",
         "readability",
         "embedding_drift",
-    }  # The datasets relation must be created first as the other two relations reference to it.
+    }
+    # The datasets relation MUST be created first as the other two relations reference to it.
 
     def __init__(self) -> None:
         """Constructor which will initialise a database connection."""
@@ -225,11 +225,13 @@ class DatabaseInterface:
 
                 time.sleep(5)
 
+        # Check if `datasets`` relation exists and create it if it doesn't, this is to ensure the `datasets` relation is created first
+        if not self.check_relation_existence("datasets"):
+            self.create_relation("datasets")
+            self.insert_datasets_data()
+
         for name in self.relation_names:
-            if not self.check_relation_existence(name) and name == "datasets":
-                self.create_relation(name)
-                self.insert_datasets_data()
-            elif not self.check_relation_existence(name):
+            if not self.check_relation_existence(name):
                 self.create_relation(name)
 
     def get_conn(self) -> extensions.connection:

--- a/utils/metric_database.py
+++ b/utils/metric_database.py
@@ -156,20 +156,17 @@ class SQLQueries:
         return sql_query
 
     @staticmethod
-    def relation_existence_query(relation_name: str) -> str:
+    def relation_existence_query() -> str:
         """SQL query for checking whether the relation specified exists or not.
-
-        Args:
-            relation_name (str): name of the relation to check for.
 
         Returns:
             str: SQL query for checking a relation existence
         """
-        sql_query = f"""
+        sql_query = """
             SELECT EXISTS (
                 SELECT FROM pg_tables
                 WHERE  schemaname = 'public'
-                AND    tablename  = '{relation_name}'
+                AND    tablename  = %(relation_name)s
             );
             """
         # This query would return a tuple such as (True,) if the relation exists, otherwise false
@@ -177,17 +174,14 @@ class SQLQueries:
         return sql_query
 
     @staticmethod
-    def get_data_from_relation(relation_name: str) -> str:
+    def get_data_from_relation() -> str:
         """SQL query for getting data from the readability relation.
-
-        Args:
-            relation_name (str): name of the relation to get data from.
 
         Returns:
             str: SQL query for getting data from the readability relation.
         """
-        sql_query = f"""
-            SELECT * FROM "{relation_name}"
+        sql_query = """
+            SELECT * FROM %(relation_name)s
             """
 
         return sql_query
@@ -303,7 +297,9 @@ class DatabaseInterface:
             bool: returns True if exists, False otherwise
         """
         result = self.execute_query(
-            SQLQueries.relation_existence_query(relation_name), fetch=True
+            SQLQueries.relation_existence_query(),
+            {"relation_name": relation_name},
+            fetch=True,
         )
         if result:  # mypy
             return bool(result[0][0])
@@ -368,7 +364,9 @@ class DatabaseInterface:
             List[Tuple[Any, ...]]: a list of tuples representing the data rows from the queried relation.
         """
         result = self.execute_query(
-            SQLQueries.get_data_from_relation(relation_name), fetch=True
+            SQLQueries.get_data_from_relation(),
+            {"relation_name": relation_name},
+            fetch=True,
         )
 
         return result  # type: ignore


### PR DESCRIPTION
This PR introduces a new column to both the readability and embedding drift tables. We will first create a new relation named `datasets` that contains a singular column, name, which acts as the primary key. The new column, named dataset, in both the readability and embedding data relations represents the dataset used to produce the response for computing the readability score. This column refers to the primary key in the datasets relation.

The methods within the metric database interface have been updated to accommodate this new column. On init, database the interface will create three relations and will populate the `datasets` relation with the two dataset names. Concurrently, the monitoring app has been modified to include the dataset's name when inserting data related to readability.

For the embedding drift, updates have been made to ensure that its payload to the metric database will encompass data for this newly created dataset column.

In reference to the [Passing parameters to SQL queries](https://www.psycopg.org/docs/usage.html#passing-parameters-to-sql-queries) from the psycopg documentation, our current method of inputting parameters into SQL queries poses significant security risks and requires manual parameter formatting. Instead, we should adopt the approach of parameterising the query as recommended. This adjustment has been implemented within this PR.

Lastly, all tests have been updated to mirror the modifications made to the files.