### PR TITLE
Bugfix/pre commit typo mypy updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,4 @@ repos:
     hooks:
       - id: typos
         args: [--config=_typos.toml]
+        pass_filenames: false

--- a/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
+++ b/steps/data_scraping_steps/scrape_mind_data/scrape_mind_data_step.py
@@ -8,7 +8,7 @@ from typing import Annotated, Dict, List, Optional
 import pandas as pd
 from bs4 import BeautifulSoup
 from config import DATA_DIR
-from requests_html import HTMLSession  # type: ignore
+from requests_html import HTMLSession
 from zenml import step
 from zenml.logger import get_logger
 

--- a/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
+++ b/steps/data_scraping_steps/scrape_nhs_data/scrape_nhs_data_step.py
@@ -8,7 +8,7 @@ from typing import Annotated, Dict, List, Optional, Union
 import pandas as pd
 from bs4 import BeautifulSoup, NavigableString, Tag
 from config import DATA_DIR
-from requests_html import HTMLSession  # type: ignore
+from requests_html import HTMLSession
 from zenml import step
 
 


### PR DESCRIPTION
This PR closes [MindGPT-72](https://github.com/fuzzylabs/MindGPT/issues/72).

Addresses minor issues with pre-commit where:
1. Configuration of `typo` was not correctly inherited from _typo.yaml
2. Historic type ignore comments, aimed to suppress `mypy` failures, were still in place for `requests_html`

Changes result in successful pre-commit run against all files in repo (as per configuration), using ```pre-commit run --all-files```.

The `typo` fix is not an optimal solution but will do the job until the root issue is fixed [here](https://github.com/crate-ci/typos/issues/347).
